### PR TITLE
Update plugin signature to latest seneca specs

### DIFF
--- a/promisify.js
+++ b/promisify.js
@@ -2,7 +2,7 @@
 var Promise = require('bluebird');
 var util = require('util');
 
-module.exports = function( options, done ) {
+module.exports = function( options ) {
 
     var seneca = this,
         senecaProto = Object.getPrototypeOf(seneca);


### PR DESCRIPTION
This avoids the legacy callback message seneca prints.
